### PR TITLE
added a plugin support for Denite; quickfix opens with Denite, if installed

### DIFF
--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -161,36 +161,40 @@ command! -nargs=0 GscopeAdd call s:GscopeAdd()
 " open quickfix
 "----------------------------------------------------------------------
 function! s:quickfix_open(size)
-	function! s:WindowCheck(mode)
-		if &buftype == 'quickfix'
-			let s:quickfix_open = 1
-			let s:quickfix_wid = winnr()
+	if exists(":Denite") == 2
+		exec "Denite quickfix"
+	else
+		function! s:WindowCheck(mode)
+			if &buftype == 'quickfix'
+				let s:quickfix_open = 1
+				let s:quickfix_wid = winnr()
+				return
+			endif
+			if a:mode == 0
+				let w:quickfix_save = winsaveview()
+			else
+				if exists('w:quickfix_save')
+					call winrestview(w:quickfix_save)
+					unlet w:quickfix_save
+				endif
+			endif
+		endfunc
+		let s:quickfix_open = 0
+		let l:winnr = winnr()			
+		noautocmd windo call s:WindowCheck(0)
+		noautocmd silent! exec ''.l:winnr.'wincmd w'
+		if s:quickfix_open != 0
+			if get(g:, 'gutentags_plus_switch', 0) != 0
+				noautocmd silent! exec ''.s:quickfix_wid.'wincmd w'
+			endif
 			return
 		endif
-		if a:mode == 0
-			let w:quickfix_save = winsaveview()
-		else
-			if exists('w:quickfix_save')
-				call winrestview(w:quickfix_save)
-				unlet w:quickfix_save
-			endif
-		endif
-	endfunc
-	let s:quickfix_open = 0
-	let l:winnr = winnr()			
-	noautocmd windo call s:WindowCheck(0)
-	noautocmd silent! exec ''.l:winnr.'wincmd w'
-	if s:quickfix_open != 0
+		exec 'botright copen '. ((a:size > 0)? a:size : '')
+		noautocmd windo call s:WindowCheck(1)
+		noautocmd silent! exec ''.l:winnr.'wincmd w'
 		if get(g:, 'gutentags_plus_switch', 0) != 0
 			noautocmd silent! exec ''.s:quickfix_wid.'wincmd w'
 		endif
-		return
-	endif
-	exec 'botright copen '. ((a:size > 0)? a:size : '')
-	noautocmd windo call s:WindowCheck(1)
-	noautocmd silent! exec ''.l:winnr.'wincmd w'
-	if get(g:, 'gutentags_plus_switch', 0) != 0
-		noautocmd silent! exec ''.s:quickfix_wid.'wincmd w'
 	endif
 endfunc
 


### PR DESCRIPTION
If you have https://github.com/Shougo/denite.nvim installed, then the quickfix windows will be opened with Denite.

This allows us to use a faster filtering system through Denite, on top of many other features.