### PR TITLE
Add support for cscope and use <cword> as default keyword

### DIFF
--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -44,10 +44,10 @@ function! s:get_gtags_file() abort
 	if !exists('b:gutentags_files')
 		return ''
 	endif
-	if !has_key(b:gutentags_files, 'gtags_cscope')
+	if !has_key(b:gutentags_files, &cscopeprg)
 		return ''
 	endif
-	let tags = b:gutentags_files['gtags_cscope']
+	let tags = b:gutentags_files[&cscopeprg]
 	if filereadable(tags)
 		return tags
 	endif
@@ -148,8 +148,6 @@ function! s:GscopeAdd() abort
 	let value = &cscopeverbose
 	let $GTAGSDBPATH = fnamemodify(dbname, ':p:h')
 	let $GTAGSROOT = root
-	let prg = get(g:, 'gutentags_gtags_cscope_executable', 'gtags-cscope')
-	execute 'set cscopeprg=' . fnameescape(prg)
 	set nocscopeverbose
 	silent exec 'cs kill -1'
 	exec 'cs add '. fnameescape(dbname)
@@ -204,14 +202,14 @@ endfunc
 " Find search
 "----------------------------------------------------------------------
 function! s:GscopeFind(bang, what, ...)
-	let keyword = (a:0 > 0)? a:1 : ''
+	let keyword = (a:0 > 0)? a:1 : a:what =~# 'f\|i\|7\|8' ? expand('<cfile>') : expand('<cword>')
 	let dbname = s:get_gtags_file()
 	let root = get(b:, 'gutentags_root', '')
 	if dbname == '' || root == ''
 		call s:ErrorMsg("no gtags database for this project, check gutentags's documents")
 		return 0
 	endif
-	if a:0 == 0 || keyword == ''
+	if keyword == ''
 		redraw! | echo '' | redraw!
 		echohl ErrorMsg
 		echom 'E560: Usage: GscopeFind a|c|d|e|f|g|i|s|t|z name'


### PR DESCRIPTION
in s:get_gtags_file(), there are
```{.vim}
	if !has_key(b:gutentags_files, 'gtags_cscope')
		return ''
	endif
	let tags = b:gutentags_files['gtags_cscope']
```

i change `'gtags_cscope'` to &cscope in order to make this plugin can work when user use other cscope.

in s:GscopeFind(), there are
```{.vim}
let keyword = (a:0 > 0)? a:1 : ''
```
when user `GscopeFind d` it will return an error because keyword is empty string. user must use `GscopeFind d keyword`.
i change it to
```{.vim}
let keyword = (a:0 > 0)? a:1 : a:what =~# 'f\|i\|7\|8' ? expand('<cfile>') : expand('<cword>')
```
So user can `GscopeFind d`, it will not result any error.
Thanks!
