### PR TITLE
add some quickfix keymap and a condition for opening quickfix win

### DIFF
--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -206,7 +206,7 @@ function! s:quickfix_open(size)
 	nnoremap <silent> <buffer> T  <C-w><CR><C-w>TgT<C-W><C-W>
 	nnoremap <silent> <buffer> v  <C-w><CR><C-w>H<C-W>b<C-W>J<C-W>t
 	exe 'nnoremap <silent> <buffer> go <CR>:copen<CR>'
-	exe 'nnoremap <silent> <buffer> q  :cclose<CR>'
+	exe 'nnoremap <silent> <buffer> q  :cclose<CR>:winc p<CR>'
 endfunc
 
 

--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -305,7 +305,7 @@ function! s:GscopeFind(bang, what, ...)
 	if winbufnr('%') == nbuf
 		call cursor(nrow, ncol)
 	endif
-    if success != 0 && a:bang == 0 && getqflist({'size':0})['size'] > 1
+	if success != 0 && a:bang == 0 && getqflist({'size':0})['size'] > 1
 		let height = get(g:, 'gutentags_plus_height', 6)
 		call s:quickfix_open(height)
 	endif

--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -199,6 +199,14 @@ function! s:quickfix_open(size)
 	if get(g:, 'gutentags_plus_switch', 0) != 0
 		noautocmd silent! exec ''.s:quickfix_wid.'wincmd w'
 	endif
+	" quickfix mappings, refer to ag.vim
+	nnoremap <silent> <buffer> h  <C-W><CR><C-w>K
+	nnoremap <silent> <buffer> H  <C-W><CR><C-w>K<C-w>b
+	nnoremap <silent> <buffer> t  <C-w><CR><C-w>T
+	nnoremap <silent> <buffer> T  <C-w><CR><C-w>TgT<C-W><C-W>
+	nnoremap <silent> <buffer> v  <C-w><CR><C-w>H<C-W>b<C-W>J<C-W>t
+	exe 'nnoremap <silent> <buffer> go <CR>:copen<CR>'
+	exe 'nnoremap <silent> <buffer> q  :cclose<CR>'
 endfunc
 
 
@@ -297,7 +305,7 @@ function! s:GscopeFind(bang, what, ...)
 	if winbufnr('%') == nbuf
 		call cursor(nrow, ncol)
 	endif
-	if success != 0 && a:bang == 0
+    if success != 0 && a:bang == 0 && getqflist({'size':0})['size'] > 1
 		let height = get(g:, 'gutentags_plus_height', 6)
 		call s:quickfix_open(height)
 	endif


### PR DESCRIPTION
Hi 大佬，
一直在用你这个插件，想加入一下改动，不会影响原始功能。
第一就是加入quickfix window的key mapping，可以退出，tab打开，vertical打开，关闭quickfix等等，这个我是吸取了ag.vim来做的，不会影响原功能。
第二个就是在quickfix item大于1个的时候再打开quickfix，这样会减少cursor再quickfix和working windows的跳转，尤其是在用 cs find g来索引Definition的时候，可以不用打开quickfix，我使用时发现，在多pane的时候，每次打开quickfix再手动关闭，cursor会到第一个window里去，所以我加入这个condition，在没有多个结果的时候，就不会打开quickfix，也可以在cs find g时把上述的跳转给省略，还是比较方便，也make sense