### PR TITLE
Add option to split quickfix window in current window

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,19 @@ let g:gutentags_modules = ['ctags', 'gtags_cscope']
 " config project root markers.
 let g:gutentags_project_root = ['.root']
 
-" generate datebases in my cache directory, prevent gtags files polluting my project
+" generate datebases in my cache directory,
+" prevent gtags files polluting my project
 let g:gutentags_cache_dir = expand('~/.cache/tags')
+
+" forbit gutentags adding gtags databases
+let g:gutentags_auto_add_gtags_scope = 0
 
 " change focus to quickfix window after search (optional).
 let g:gutentags_plus_switch = 1
+
+" open the quickfix window inside the current window instead of at the
+" bottom of all windows (optional).
+let g:gutentags_plus_follow = 1
 ```
 
 NOTE: gutentags will identify current project root by by root markers (.git/.svn/.root). if your project is not in any git/svn repository, gutentags will not generate gtags database for it. To avoid this, you can create an empty `.root` file in your project root, and gutentags will know where is your project root and generate gtags database for it.

--- a/doc/gutentags_plus.txt
+++ b/doc/gutentags_plus.txt
@@ -67,11 +67,19 @@ Configuration ~
   " config project root markers.
   let g:gutentags_project_root = ['.root']
 
-  " generate datebases in my cache directory, prevent gtags files polluting my p                                                                                                             roject
+  " generate datebases in my cache directory, 
+  " prevent gtags files polluting my project
   let g:gutentags_cache_dir = expand('~/.cache/tags')
 
   " forbid gutentags adding gtags databases
   let g:gutentags_auto_add_gtags_cscope = 0
+
+  " change focus to quickfix window after search (optional).
+  let g:gutentags_plus_switch = 1
+
+  " open the quickfix window inside the current window instead of at the 
+  " bottom of all windows (optional).
+  let g:gutentags_plus_follow = 1
 <
 ===============================================================================
                                                         *gutentags_plus-command*

--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -18,7 +18,7 @@ else
 endif
 
 let g:gutentags_auto_add_gtags_cscope = 0
-let g:gutentags_quickfix_follow = 1
+let g:gutentags_plus_follow = 0
 
 "----------------------------------------------------------------------
 " strip heading and ending spaces 

--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -21,7 +21,7 @@ let g:gutentags_auto_add_gtags_cscope = 0
 let g:gutentags_plus_follow = 0
 
 "----------------------------------------------------------------------
-" strip heading and ending spaces 
+" strip heading and ending spaces
 "----------------------------------------------------------------------
 function! s:string_strip(text)
 	return substitute(a:text, '^\s*\(.\{-}\)\s*$', '\1', '')
@@ -184,11 +184,11 @@ function! s:quickfix_open(size)
 		endif
 	endfunc
 	let s:quickfix_open = 0
-	let l:winnr = winnr()			
+	let l:winnr = winnr()
 	noautocmd windo call s:WindowCheck(0)
 	noautocmd silent! exec ''.l:winnr.'wincmd w'
 	if s:quickfix_open != 0
-        if get(g:, 'gutentags_quickfix_follow', 0) != 0
+        if get(g:, 'gutentags_plus_follow', 0) != 0
             exec 'cclose'
         else
             if get(g:, 'gutentags_plus_switch', 0) != 0
@@ -197,7 +197,7 @@ function! s:quickfix_open(size)
             return
         endif
 	endif
-    if get(g:, 'gutentags_quickfix_follow', 0) != 0
+    if get(g:, 'gutentags_plus_follow', 0) != 0
         exec 'rightbelow copen '. ((a:size > 0)? a:size : '')
     else
         exec 'botright copen '. ((a:size > 0)? a:size : '')
@@ -478,7 +478,7 @@ function! s:signature(funname, fn_only, filetype)
 				continue
 			elseif ft == 'cs' && ename != 'cs'
 				continue
-			elseif ft == 'php' 
+			elseif ft == 'php'
 				if index(['php', 'php4', 'php5', 'php6'], ename) < 0
 					continue
 				endif

--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -18,7 +18,6 @@ else
 endif
 
 let g:gutentags_auto_add_gtags_cscope = 0
-let g:gutentags_plus_follow = 0
 
 "----------------------------------------------------------------------
 " strip heading and ending spaces

--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -18,7 +18,7 @@ else
 endif
 
 let g:gutentags_auto_add_gtags_cscope = 0
-
+let g:gutentags_quickfix_follow = 1
 
 "----------------------------------------------------------------------
 " strip heading and ending spaces 
@@ -188,12 +188,20 @@ function! s:quickfix_open(size)
 	noautocmd windo call s:WindowCheck(0)
 	noautocmd silent! exec ''.l:winnr.'wincmd w'
 	if s:quickfix_open != 0
-		if get(g:, 'gutentags_plus_switch', 0) != 0
-			noautocmd silent! exec ''.s:quickfix_wid.'wincmd w'
-		endif
-		return
+        if get(g:, 'gutentags_quickfix_follow', 0) != 0
+            exec 'cclose'
+        else
+            if get(g:, 'gutentags_plus_switch', 0) != 0
+                noautocmd silent! exec ''.s:quickfix_wid.'wincmd w'
+            endif
+            return
+        endif
 	endif
-	exec 'botright copen '. ((a:size > 0)? a:size : '')
+    if get(g:, 'gutentags_quickfix_follow', 0) != 0
+        exec 'rightbelow copen '. ((a:size > 0)? a:size : '')
+    else
+        exec 'botright copen '. ((a:size > 0)? a:size : '')
+    endif
 	noautocmd windo call s:WindowCheck(1)
 	noautocmd silent! exec ''.l:winnr.'wincmd w'
 	if get(g:, 'gutentags_plus_switch', 0) != 0


### PR DESCRIPTION
Howdy,

I was trying out some different options in other plugins for how the quickfix window opens, and didn't see the same flexibility in `gutentags_plus`, so I went ahead and added an option that essentially uses `rightbelow` as a split method. The result is that the quickfix window "follows" you around when you open it in different windows, hence the name of the option.

Hopefully you think it's useful enough to incorporate.