### PR TITLE
Avoid redrawing when displaying error messages

### DIFF
--- a/plugin/gutentags_plus.vim
+++ b/plugin/gutentags_plus.vim
@@ -39,7 +39,6 @@ endfunc
 " display error message
 "----------------------------------------------------------------------
 function! s:ErrorMsg(msg)
-	redraw! | echo "" | redraw!
 	echohl ErrorMsg
 	echom 'ERROR: '. a:msg
 	echohl NONE


### PR DESCRIPTION
I am not sure why this double redraw was ever needed in the first place, but it makes my terminal very slow whenever I need to GscopeAdd